### PR TITLE
Change role from roles/dns.admin → roles/editor

### DIFF
--- a/src/customers/bassene-web.ts
+++ b/src/customers/bassene-web.ts
@@ -18,7 +18,7 @@ export const dnsRole = new gcp.projects.IAMMember(
   'bassene-web-dns-iam',
   {
     member: pulumi.interpolate`serviceAccount:${setup.serviceAccount.email}`,
-    role: 'roles/dns.admin',
+    role: 'roles/editor',
   },
   { provider: setup.googleProvider },
 );


### PR DESCRIPTION
We'll need to activate some API services etc.

Didn't want to add separate roles. It's probably good with `roles/editor` though. This PR can be reversed if someone doesn't want it :)